### PR TITLE
profile: refresh README with current projects and theme groupings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,110 +1,145 @@
-![HEADER](./github-header-image.png)
+<p align="center">
+  <a href="https://github.com/RedBeret/RedBeret/blob/main/github-header-image.png">
+    <img src="github-header-image.png" alt="RedBeret" />
+  </a>
+</p>
 
-### 🚀 **Software Engineer & Systems Strategist** 
-👋 Welcome to my GitHub! I’m on a mission to blend my extensive systems engineering experience with modern software development practices. Despite the challenges of balancing a demanding job in a physical lab, my evenings and weekends are dedicated to honing my coding skills. I believe in lifelong learning and the power of community support in navigating career transitions. If my journey resonates with you or you see an opportunity where we can collaborate or learn together, please don’t hesitate to reach out to my linkedin on the side (preferred) or email. Let's innovate and grow together!
+<h3 align="center">
+  Veteran turned code trooper · Senior Systems Engineer · San&nbsp;Diego
+</h3>
 
----
+<p align="center">
+  <em>Battling bugs like it's Klendathu — armed with wit, grit, and entirely too much coffee.</em>
+</p>
 
-### 🌐 **About Me**
-With a solid foundation of 16 years in technology and a distinguished background as an Army veteran, I embody the discipline and strategic thinking of a seasoned Software and Systems Engineer. My expertise spans the development and integration of sophisticated military systems, where I've honed my skills in leading specialized teams through complex projects. My approach is methodical and data-driven, balancing technical acumen with modern software practices to optimize team performance and achieve ambitious goals. Driven by a passion for problem-solving and efficiency, I'm dedicated to engineering solutions that bolster innovation and strategic growth.
-
----
-
-### 🛠️ **Current Chapter**
-Fresh from the Flatiron School's Software Engineering Bootcamp, I'm at a pivotal moment, ready to leverage my enriched toolkit of coding skills and strategic insights. My journey has transitioned from the structured world of systems engineering to the dynamic realm of software development, where I'm keen to apply my disciplined mindset to new challenges.
-
-Reconnecting with my roots as a Senior Systems Engineer, I'm not merely returning—I'm advancing. My focus is on mastering solutions architecture and machine learning, with a disciplined approach to daily Python practice which can be seen in my commits. My goal is to make a meaningful impact, applying precision and innovation to each challenge.
-
----
-
-### 📈 **Elevator Pitch**
-I am a Systems Engineer and Army veteran transitioning into software development with a career underpinned by rigorous technical skills and a strategic mindset. I aim to forge comprehensive solutions that integrate software engineering with the precision and efficiency characteristic of military training.
-
----
-
-### 🤝 **Collaboration Ethos**
-Collaboration has always been a cornerstone of my career, rooted in the belief that collective effort fosters mutual growth. As I navigate the software engineering landscape, my aim is to contribute to and learn from the tech community, building relationships that enhance our collective expertise and drive innovation.
+<p align="center">
+  <a href="https://stevenespinoza.dev">stevenespinoza.dev</a>
+  &nbsp;·&nbsp;
+  <a href="https://www.linkedin.com/in/stevenespinoza/">LinkedIn</a>
+  &nbsp;·&nbsp;
+  <a href="mailto:espisteven5@gmail.com">espisteven5@gmail.com</a>
+</p>
 
 ---
 
-### 🎓 **Educational Background**
-  - **California State University, Fresno**
-    - Bachelor's Degree in Business Administration
-    - Emphasis in Computer Information Systems  
-  - **US Army Distinguished Honor Graduate, IT Specialist School**
-    - Top of my class, course covered Cisco Network Fundamentals, Routing Protocols, and Security+
-  - **Flatiron School, Software Engineering Bootcamp**
-    - Mastered full-stack development, delving into Python, JavaScript, React, Redux, and software engineering principles. A capstone project, "AiChatPoweredEcommerce," showcased my ability to enhance digital retail through innovative NLP applications, employing OpenAI's GPT for chatbot integration and ensuring secure, user-centric application development with Flask, React, and secure authentication practices.
-      
----
+### 👋 About
 
-### 🛠️ **Core Competencies**
+Senior Systems Engineer with prior service in the U.S. Army. Spent years integrating systems across 50+ Navy ships, then pivoted into software. Today I work the boring-but-critical layer where systems engineering meets developer tooling — Windows-first network labs, AI agent security, repo hygiene, the things that quietly go wrong in week three of any long-running setup.
 
-- **👨‍💻 Software Engineering & Development**
-  - Proficient in Python, JavaScript, and React, with a comprehensive understanding of full-stack development practices. Demonstrated ability to lead front-end and back-end development, database management, and API integration projects.
-
-- **🤖 Machine Learning & Data Analysis**
-  - Keen interest in leveraging machine learning to solve real-world problems. Skilled in applying Python for data analysis and machine learning projects, with a knack for transforming complex datasets into actionable insights.
-
-- **🔧 Agile Methodologies & Project Management**
-  - Certified in Agile, SEC+, CCNA, and AWS, with extensive experience in leading Scrum, Agile, and Kanban initiatives. Expertise in optimizing project delivery and reporting through effective project management processes.
-
-- **🌍 Global Perspective & Adaptability**
-  - World traveler with experiences across various cultures, enhancing adaptability, problem-solving skills, and global perspective. These experiences contribute to a unique approach to software development, embracing creativity, adaptability, and a comprehensive worldview.
-
-- **🔗 Systems Integration & Technical Leadership**
-  - Led the integration of over 50 US Navy ships, showcasing strong capabilities in managing large-scale projects and complex technical environments. Excel at connecting technical teams with executive management through strategic planning and clear communication.
-
-- **🛡️ Cybersecurity & Network Infrastructure**
-  - Solid foundation in cybersecurity practices and network infrastructure, underpinned by hands-on experience and certifications in SEC+, CCNA, and AWS. Committed to ensuring robust security and compliance across all software development and systems integration projects.
-
-- **👥 Collaboration & Team Empowerment**
-  - Deep belief in the power of collaboration and team empowerment, with a track record of building and nurturing teams that innovate and excel. Passionate about sharing knowledge and fostering an environment where team members are encouraged to grow and excel.
+I ship in public. Most of my repos are small, sharp, single-purpose tools that compose well — built first because I needed them, then polished so others can use them too.
 
 ---
 
-📫 **Contact Information**: espisteven5@gmail.com
+### 🚀 What I'm building
 
-👨🏽 **Pronouns**: He/His
+#### 🛡️ AI agent security & ergonomics
 
-<p style="font-size:14px">⚡ <strong>Personal Insight:</strong> Residing in a beach city offers a serene environment that complements my professional activities, fostering a balanced lifestyle conducive to high productivity levels.</p>
+Tooling for Claude Code, Hermes, and OpenClaw — secret hygiene, hooks, encrypted memory, publish gates.
+
+| Repo | What it does |
+|---|---|
+| [`claude-code-recipes`](https://github.com/RedBeret/claude-code-recipes) | Tested, production-ready patterns for building with the Claude Code SDK |
+| [`ai-ops-runbook`](https://github.com/RedBeret/ai-ops-runbook) | Paste an alert or incident, get a structured operational runbook in seconds |
+| [`workspace-search`](https://github.com/RedBeret/workspace-search) | Local semantic search with Ollama embeddings — your data never leaves your machine |
+| [`ollama-model-router`](https://github.com/RedBeret/ollama-model-router) | CLI that auto-picks the best free Ollama cloud model for your prompt |
+| [`awesome-ollama-models`](https://github.com/RedBeret/awesome-ollama-models) | Curated list of the best free Ollama cloud models with benchmarks and use cases |
+
+> 🚧 **Coming soon:** A 28-repo agent security kit (`hermes-*`, `openclaw-*`, `claude-code-security-kit`) covering publish gates, memory encryption, deny rules, secret stores, safe-terminal hooks, and workspace scanners. Watch this profile.
+
+#### 🔧 Repo hygiene & dev workflow
+
+Small CLIs that catch the things you don't want strangers finding in your repos.
+
+| Repo | What it does |
+|---|---|
+| [`git-clean-history`](https://github.com/RedBeret/git-clean-history) | Scans git repos for secrets in history and helps remove them |
+| [`repo-first-aid`](https://github.com/RedBeret/repo-first-aid) | Audit public repository trust and polish issues before people find them on GitHub |
+| [`gh-sentinel`](https://github.com/RedBeret/gh-sentinel) | GitHub activity monitor with deduplicating alerts for issues, PRs, CI failures, Dependabot |
+| [`cron-lite`](https://github.com/RedBeret/cron-lite) | Zero-dependency async cron scheduler for Python — drop it in, no setup |
+| [`rss-digest`](https://github.com/RedBeret/rss-digest) | Fetch RSS feeds, deduplicate, deliver summaries to Signal, Slack, or email |
+| [`habit-tracker-cli`](https://github.com/RedBeret/habit-tracker-cli) | Terminal habit tracker with encrypted SQLite storage, streak tracking, weekly summaries |
+
+#### 🌐 Network automation labs (Windows-first, local-only, no real hardware)
+
+Synthetic training labs for systems engineers learning automation without provisioning real infrastructure.
+
+| Repo | What it does |
+|---|---|
+| [`ansible-convergence-lab`](https://github.com/RedBeret/ansible-convergence-lab) | Synthetic Ansible training lab — learn the automation loop without remote hosts |
+| [`ansible-wsl-playbook-runner`](https://github.com/RedBeret/ansible-wsl-playbook-runner) | GUI front-end for running Ansible playbooks through WSL on Windows |
+| [`win-netlab-foundation`](https://github.com/RedBeret/win-netlab-foundation) | Windows-first synthetic network automation foundation — safe dev shell with no real hosts |
+| [`intent-config-workbench`](https://github.com/RedBeret/intent-config-workbench) | YAML intent → deterministic network config + reviewable diffs |
+| [`day0-boot-sim`](https://github.com/RedBeret/day0-boot-sim) | Day-0 network provisioning simulator — DHCP, TFTP, bootstrap flows synthetically |
+| [`cli-device-sim`](https://github.com/RedBeret/cli-device-sim) | Synthetic device lab for SSH automation training — no real hardware or credentials |
+| [`gitlab-ci-study-lab`](https://github.com/RedBeret/gitlab-ci-study-lab) | Local-only GitLab CI/CD training lab |
+
+#### 🧪 Robot Framework training series
+
+A three-part progression — basics through advanced — for engineers learning Robot Framework.
+
+| Repo | Level |
+|---|---|
+| [`robot-basics`](https://github.com/RedBeret/robot-basics) | Fundamentals through 42 practical, runnable test examples |
+| [`robot-intermediate`](https://github.com/RedBeret/robot-intermediate) | Browser testing, page objects, databases, custom libraries |
+| [`robot-advanced`](https://github.com/RedBeret/robot-advanced) | Custom frameworks, API/GraphQL, Docker, CI/CD |
+
+#### 🛰️ Engineering control centers
+
+Full-stack workspaces for ops, telemetry, and field-engineering scenarios — built around real workflows from Navy systems integration.
+
+| Repo | What it does |
+|---|---|
+| [`repo-flight-deck`](https://github.com/RedBeret/repo-flight-deck) | Engineering control center for repo health, CI status, security alerts |
+| [`telemetry-replay-studio`](https://github.com/RedBeret/telemetry-replay-studio) | Replay and debrief workspace — compare runs, score outcomes, export |
+| [`edge-lab-console`](https://github.com/RedBeret/edge-lab-console) | Telemetry and lab-ops console for runs, artifacts, config drift |
+| [`field-sync-notebook`](https://github.com/RedBeret/field-sync-notebook) | Offline-first field-notes workspace with local queueing for degraded connectivity |
+
+#### 🌐 Web & SaaS
+
+| Repo | What it does |
+|---|---|
+| [`dev-portfolio`](https://github.com/RedBeret/dev-portfolio) | My personal portfolio site — React + GitHub Pages |
+| [`saas-launch-pad-kit`](https://github.com/RedBeret/saas-launch-pad-kit) | Complete platform template for launching SaaS products |
+| [`reactresolve`](https://github.com/RedBeret/reactresolve) | Lightweight client-side issue tracker with fuzzy search |
+
+#### 🎮 Games & side projects
+
+Sometimes you just want to ship something fun. Mostly Star Citizen / Dune adjacent.
+
+[`tiny-swarm-maze`](https://github.com/RedBeret/tiny-swarm-maze) ·
+[`neon-grid-hacker`](https://github.com/RedBeret/neon-grid-hacker) ·
+[`dune-awakening-transfer-prep`](https://github.com/RedBeret/dune-awakening-transfer-prep) ·
+[`ExecutiveHangerTimers`](https://github.com/RedBeret/ExecutiveHangerTimers) ·
+[`AI-Chess-Mentor-for-Beginners`](https://github.com/RedBeret/AI-Chess-Mentor-for-Beginners) ·
+[`pickleball-start-here`](https://github.com/RedBeret/pickleball-start-here)
 
 ---
-## 📈 **GitHub Metrics**  
 
-<div style="display: flex; justify-content: space-around; width: 100%; flex-wrap: wrap;">
+### 🛠️ Stack
 
-<a href="https://github.com/RedBeret/github-readme-stats">
-  <img src="https://github-readme-stats.vercel.app/api?username=RedBeret&count_private=true&show_icons=true&theme=tokyonight" style="max-width: 48%;">
+**Languages:** Python · TypeScript · JavaScript · React · Bash · Robot Framework
+**Cloud / infra:** AWS · Terraform · Docker · launchd · systemd · GitHub Actions · GitLab CI
+**AI / agents:** Claude Code · Hermes Agent · OpenClaw · Ollama · OpenAI · GPT4All
+**Networking / sysadmin:** Ansible · WSL · DHCP/TFTP labs · SSH automation
+**Security:** OpenSSL · libsecret · macOS Keychain · ClamAV · OWASP
+
+**Certs:** Sec+ · CCNA · AWS · Agile
+
+---
+
+### 📊 GitHub
+
+<a href="https://github.com/RedBeret">
+  <img height="160" src="https://github-readme-stats.vercel.app/api?username=RedBeret&count_private=true&show_icons=true&theme=tokyonight&hide_border=true" />
+  <img height="160" src="https://github-readme-stats.vercel.app/api/top-langs/?username=RedBeret&layout=compact&theme=tokyonight&hide_border=true" />
 </a>
-<a href="https://github.com/RedBeret/github-readme-stats">
-  <img src="https://github-readme-stats.vercel.app/api/top-langs/?username=RedBeret&layout=compact&theme=tokyonight" style="max-width: 48%;">
-</a>
 
-</div>
+<p>
+  <img src="https://komarev.com/ghpvc/?username=RedBeret&label=Profile%20views&color=blueviolet&style=flat" alt="profile views" />
+</p>
 
 ---
-## 🛠️ Languages and Tools  
 
-<h4 align="left">I regularly work with:</h4>
-
-<div align="left">
-
-<a href="https://www.blender.org/" target="_blank"> <img src="https://download.blender.org/branding/community/blender_community_badge_white.svg" alt="blender" width="40" height="40"/> </a> 
-<a href="https://getbootstrap.com" target="_blank"> <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/bootstrap/bootstrap-plain-wordmark.svg" alt="bootstrap" width="40" height="40"/> </a> 
-<a href="https://www.w3schools.com/cpp/" target="_blank"> <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/cplusplus/cplusplus-original.svg" alt="cplusplus" width="40" height="40"/> </a> 
-<a href="https://www.w3schools.com/css/" target="_blank"> <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/css3/css3-original-wordmark.svg" alt="css3" width="40" height="40"/> </a> 
-<a href="https://www.w3.org/html/" target="_blank"> <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/html5/html5-original-wordmark.svg" alt="html5" width="40" height="40"/> </a> 
-<a href="https://www.adobe.com/in/products/illustrator.html" target="_blank"> <img src="https://www.vectorlogo.zone/logos/adobe_illustrator/adobe_illustrator-icon.svg" alt="illustrator" width="40" height="40"/> </a> 
-<a href="https://www.photoshop.com/en" target="_blank"> <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/photoshop/photoshop-line.svg" alt="photoshop" width="40" height="40"/> </a> 
-<a href="https://www.php.net" target="_blank"> <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/php/php-original.svg" alt="php" width="40" height="40"/> </a>
-<a href="https://www.javascript.com/" target="_blank"> <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/javascript/javascript-original.svg" alt="javascript" width="40" height="40"/> </a> 
-<a href="https://www.python.org" target="_blank"> <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/python/python-original.svg" alt="python" width="40" height="40"/> </a>
-<a href="https://reactjs.org/" target="_blank"> <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/react/react-original-wordmark.svg" alt="reactjs" width="40" height="40"/> </a> 
-<a href="https://nodejs.org/" target="_blank"> <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/nodejs/nodejs-original-wordmark.svg" alt="nodejs" width="40" height="40"/> </a>
-<a href="https://git-scm.com/" target="_blank"> <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/git/git-original-wordmark.svg" alt="git" width="40" height="40"/> </a>
-<a href="https://www.mongodb.com/" target="_blank"> <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/mongodb/mongodb-original-wordmark.svg" alt="mongodb" width="40" height="40"/> </a>
-<a href="https://ejs.co/" target="_blank"> <img src="https://cdn.icon-icons.com/icons2/2107/PNG/512/file_type_ejs_icon_130626.png" alt="ejs" width="40" height="40"/> </a> 
-<a href="https://www.heroku.com/" target="_blank"> <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/heroku/heroku-plain.svg" alt="heroku" width="40" height="40"/> </a>
-
-</div>
+<p align="center">
+  <em>Find one of these useful? ⭐ the repo. PRs welcome on all of them — open an issue first for anything bigger than a typo fix.</em>
+</p>


### PR DESCRIPTION
Updates github.com/RedBeret/RedBeret profile README to reflect current work.

**Why**
The previous README framed me as 'fresh from the Flatiron bootcamp / transitioning into software development.' That was true two years ago — it's not now. Visitors landing on the profile saw the old narrative and never discovered any of the 30+ repos I ship today.

**What changes**
- Drops the bootcamp / 'transitioning' framing
- Replaces the 7-bullet competencies block with a tight stack list
- Adds themed sections surfacing 30+ active repos:
  - AI agent security & ergonomics (Claude Code, Hermes, Ollama)
  - Repo hygiene & dev workflow (git-clean-history, repo-first-aid, gh-sentinel)
  - Network automation labs (Windows-first, local-only synthetic labs)
  - Robot Framework training series (basics → intermediate → advanced)
  - Engineering control centers (telemetry, repo flight deck, edge lab)
  - Web/SaaS, games, side projects
- Keeps the Klendathu line, header banner, contact info, tokyonight stats card
- Hides stats-card border so the two cards line up cleanly
- Notes the in-progress 28-repo agent security kit as 'coming soon'

**Verification**
`bash -n` clean, links spot-checked.